### PR TITLE
Add e2e test for DisablePacketMTUCheck

### DIFF
--- a/test/e2e/gateway_mtu.go
+++ b/test/e2e/gateway_mtu.go
@@ -1,0 +1,36 @@
+package e2e
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+)
+
+var _ = ginkgo.Describe("Check whether gateway-mtu-support annotation on node is set based on disable-pkt-mtu-check value", func() {
+	var nodes *v1.NodeList
+	f := wrappedTestFramework("gateway-mtu-support")
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		ginkgo.By("Get all nodes")
+		nodes, err = e2enode.GetReadySchedulableNodes(context.TODO(), f.ClientSet)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+	ginkgo.When("DisablePacketMTUCheck is either not set or set to false", func() {
+		ginkgo.It("Verify whether gateway-mtu-support annotation is not set on nodes when DisablePacketMTUCheck is either not set or set to false", func() {
+			if !isDisablePacketMTUCheckEnabled() {
+				for _, node := range nodes.Items {
+					supported := getGatewayMTUSupport(&node)
+					gomega.Expect(supported).To(gomega.Equal(true))
+
+				}
+			} else {
+				framework.Logf("Skipping the test as DisablePacketMTUCheck is set to true")
+			}
+		})
+	})
+})

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -39,6 +39,8 @@ const (
 	ovnNodeSubnets = "k8s.ovn.org/node-subnets"
 	// ovnNodeZoneNameAnnotation is the node annotation name to store the node zone name.
 	ovnNodeZoneNameAnnotation = "k8s.ovn.org/zone-name"
+	// ovnGatewayMTUSupport annotation determines if options:gateway_mtu shall be set for a node's gateway router
+	ovnGatewayMTUSupport = "k8s.ovn.org/gateway-mtu-support"
 )
 
 var containerRuntime = "docker"
@@ -1163,4 +1165,21 @@ func routeToNode(nodeName string, ips []string, mtu int, add bool) error {
 		}
 	}
 	return nil
+}
+
+// It checks whether config.DisablePacketMTUCheck is set or not
+func isDisablePacketMTUCheckEnabled() bool {
+	val, present := os.LookupEnv("OVN_DISABLE_PKT_MTU_CHECK")
+	return present && val == "true"
+}
+
+// getGatewayMTUSupport returns true if gateway-mtu-support annotataion
+// is not set on the node, otherwise it returns false as the value of the
+// annotation also get set to false
+func getGatewayMTUSupport(node *v1.Node) bool {
+	_, ok := node.Annotations[ovnGatewayMTUSupport]
+	if !ok {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
This e2e test verifies whether 'k8s.ovn.org/gateway-mtu-support' annotation is being added to all nodes and being set to 'false' when `disable-pkt-mtu-check` is set to 'true'. This annotation should be absent from node objects when either `disable-pkt-mtu-check` is unset or set to 'false'

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->